### PR TITLE
make slay regex also capture sign

### DIFF
--- a/src/app/core/services/cf-parser.service.ts
+++ b/src/app/core/services/cf-parser.service.ts
@@ -52,7 +52,7 @@ export class CfParserService {
       var words = temp0.split(/ /)
       var slaying = 0
       for (var line=0; line < words.length; line +=1) {
-        var slayRe = /Slay[\+-](\d+)/
+        var slayRe = /Slay([\+-]\d+)/
         if (slayRe.test(words[line])) {
           slaying = parseInt(slayRe.exec(words[line])[1]) + slaying
         }


### PR DESCRIPTION
The slay regex was only capturing the value of slay but not the sign, causing it to parse negative slay values as positive, i have changed the regex to also capture the sign.